### PR TITLE
Allow loading of files with non-identifier characters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,9 +164,8 @@ export default function (babel) {
                         let thing = t.expressionStatement(
                             t.assignmentExpression("=", t.memberExpression(
                                 t.identifier(wildcardName),
-                                t.identifier(
-                                    fancyName
-                                )
+                                t.stringLiteral(fancyName),
+                                true
                             ), id
                         ));
                         


### PR DESCRIPTION
File names like `foo-bar.js` and `1.0.0.md` trigger compiler errors. By using a string literal in a computed property instead, any file name should be usable with the plugin.