### PR TITLE
Do not try to transform imports of files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-lib
 
 # Logs
 logs

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,40 @@
+'use strict';Object.defineProperty(exports,'__esModule',{value:true});exports.default=function(babel){var t=babel.types;return{visitor:{ImportDeclaration:function ImportDeclaration(path,state){var node=path.node,dec=void 0;var src=path.node.source.value;// Don't do anything if not a relative path
+// if if not a relative path then a module
+if(src[0]!=='.'&&src[0]!=='/')return;var addWildcard=false,// True if should perform transform
+wildcardName=void 0;// Name of the variable the wilcard will go in
+// not set if you have a filter { A, B, C }
+var filterNames=[];// e.g. A, B, C
+// has a /* specifing explicitly to use wildcard
+var isExplicitWildcard=/\/\*$/.test(src);// in the above case we need to remove the trailing /*
+if(isExplicitWildcard){path.node.source.value=path.node.source.value.substring(0,src.length-2);src=path.node.source.value}// Get current filename so we can try to determine the folder
+var name=this.file.parserOpts.sourceFileName||this.file.parserOpts.filename;var files=[];var dir=_path3.default.join(_path3.default.dirname(name),src);// path of the target dir.
+for(var i=0;i<node.specifiers.length;i++){dec=node.specifiers[i];if(t.isImportNamespaceSpecifier(dec)&&!_fs3.default.statSync(dir).isFile()){addWildcard=true;wildcardName=node.specifiers[i].local.name;node.specifiers.splice(i,1)}// This handles { A, B, C } from 'C/*'
+if(t.isImportSpecifier(dec)&&isExplicitWildcard){// original: the actual name to lookup
+// local: the name to import as, may be same as original
+// We do this because of `import { A as B }`
+filterNames.push({original:dec.imported.name,local:dec.local.name});addWildcard=true;// Remove the specifier
+node.specifiers.splice(i,1)}}// All the extensions that we should look at
+var exts=state.opts.exts||['js','es6','es','jsx'];if(addWildcard){// Add the original object. `import * as A from 'foo';`
+//  this creates `const A = {};`
+// For filters this will be empty anyway
+if(filterNames.length===0){var obj=t.variableDeclaration('const',[t.variableDeclarator(t.identifier(wildcardName),t.objectExpression([]))]);path.insertBefore(obj)}// Will throw if the path does not point to a dir
+try{var r=_fs3.default.readdirSync(dir);for(var i=0;i<r.length;i++){// Check extension is of one of the aboves
+if(exts.indexOf(_path3.default.extname(r[i]).substring(1))>-1){files.push(r[i])}}}catch(e){console.warn('Wildcard for '+name+' points at '+src+' which is not a directory.');return}// This is quite a mess but it essentially formats the file
+// extension, and adds it to the object
+for(var i=0;i<files.length;i++){// name of temp. variable to store import before moved
+// to object
+var id=path.scope.generateUidIdentifier('wcImport');var file=files[i];// Strip extension
+var fancyName=file.replace(/(?!^)\.[^.\s]+$/,'');// Handle dotfiles, remove prefix `.` in that case
+if(fancyName[0]==='.'){fancyName=fancyName.substring(1)}// If we're allowed to camel case, which is default, we run it
+// through this regex which converts it to a PascalCase variable.
+if(state.opts.noCamelCase!==true){fancyName=fancyName.match(/[A-Z][a-z]+(?![a-z])|[A-Z]+(?![a-z])|([a-zA-Z\d]+(?=-))|[a-zA-Z\d]+(?=_)|[a-z]+(?=[A-Z])|[A-Za-z0-9]+/g).map(function(s){return s[0].toUpperCase()+s.substring(1)}).join('')}// Now we're 100% settled on the fancyName, if the user
+// has provided a filer, we will check it:
+if(filterNames.length>0){// Find a filter name
+var res=null;for(var j=0;j<filterNames.length;j++){if(filterNames[j].original===fancyName){res=filterNames[j];break}}if(res===null)continue;fancyName=res.local}// This will remove file extensions from the generated `import`.
+// This is useful if your src/ files are for example .jsx or
+// .es6 but your generated files are of a different extension.
+// For situations like webpack you may want to disable this
+var name;if(state.opts.nostrip!==true){name='./'+_path3.default.join(src,_path3.default.basename(file))}else{name='./'+_path3.default.join(src,file)}// Special behavior if 'filterNames'
+if(filterNames.length>0){var _importDeclaration=t.importDeclaration([t.importDefaultSpecifier(t.identifier(fancyName))],t.stringLiteral(name));path.insertAfter(_importDeclaration);continue}// Generate temp. import declaration
+var importDeclaration=t.importDeclaration([t.importDefaultSpecifier(id)],t.stringLiteral(name));// Assign it
+var thing=t.expressionStatement(t.assignmentExpression('=',t.memberExpression(t.identifier(wildcardName),t.stringLiteral(fancyName),true),id));path.insertAfter(thing);path.insertAfter(importDeclaration)}if(path.node.specifiers.length===0){path.remove()}}}}}};var _path2=require('path');var _path3=_interopRequireDefault(_path2);var _fs2=require('fs');var _fs3=_interopRequireDefault(_fs2);function _interopRequireDefault(obj){return obj&&obj.__esModule?obj:{default:obj}}

--- a/src/index.js
+++ b/src/index.js
@@ -22,17 +22,23 @@ export default function (babel) {
                 
                 // has a /* specifing explicitly to use wildcard
                 let isExplicitWildcard = /\/\*$/.test(src);
-                
+
                 // in the above case we need to remove the trailing /*
                 if (isExplicitWildcard) {
                     path.node.source.value = path.node.source.value.substring(0, src.length - 2);
                     src = path.node.source.value;
                 }
                 
+                // Get current filename so we can try to determine the folder
+                var name = this.file.parserOpts.sourceFileName || this.file.parserOpts.filename;
+
+                var files = [];
+                var dir = _path.join(_path.dirname(name), src); // path of the target dir.
+
                 for (var i = 0; i < node.specifiers.length; i++) {
                     dec = node.specifiers[i];
                     
-                    if (t.isImportNamespaceSpecifier(dec)) {
+                    if (t.isImportNamespaceSpecifier(dec) && !_fs.statSync(dir).isFile()) {
                         addWildcard = true;
                         wildcardName = node.specifiers[i].local.name;
                         node.specifiers.splice(i, 1);
@@ -73,12 +79,6 @@ export default function (babel) {
                         );
                         path.insertBefore(obj);
                     }
-                    
-                    // Get current filename so we can try to determine the folder
-                    var name = this.file.parserOpts.sourceFileName || this.file.parserOpts.filename;
-                    
-                    var files = [];
-                    var dir = _path.join(_path.dirname(name), src); // path of the target dir.
                     
                     // Will throw if the path does not point to a dir
                     try {

--- a/test/fixtures/fileWildcard/actual.js
+++ b/test/fixtures/fileWildcard/actual.js
@@ -1,0 +1,2 @@
+import * as all from './my-module.js';
+console.log(all.hello);

--- a/test/fixtures/fileWildcard/expected.js
+++ b/test/fixtures/fileWildcard/expected.js
@@ -1,0 +1,10 @@
+
+'use strict';
+
+var _myModule = require('./my-module.js');
+
+var all = _interopRequireWildcard(_myModule);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+console.log(all.hello);

--- a/test/fixtures/fileWildcard/my-module.js
+++ b/test/fixtures/fileWildcard/my-module.js
@@ -1,0 +1,1 @@
+export let hello = 'Hello World!';


### PR DESCRIPTION
Allow wildcard importing of files such as `import * as foo from './my-module.js'`.