### PR TITLE
Do not try to transform imports of files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,17 +22,23 @@ export default function (babel) {
                 
                 // has a /* specifing explicitly to use wildcard
                 let isExplicitWildcard = /\/\*$/.test(src);
-                
+
                 // in the above case we need to remove the trailing /*
                 if (isExplicitWildcard) {
                     path.node.source.value = path.node.source.value.substring(0, src.length - 2);
                     src = path.node.source.value;
                 }
                 
+                // Get current filename so we can try to determine the folder
+                var name = this.file.parserOpts.sourceFileName || this.file.parserOpts.filename;
+
+                var files = [];
+                var dir = _path.join(_path.dirname(name), src); // path of the target dir.
+
                 for (var i = 0; i < node.specifiers.length; i++) {
                     dec = node.specifiers[i];
                     
-                    if (t.isImportNamespaceSpecifier(dec)) {
+                    if (t.isImportNamespaceSpecifier(dec) && !_fs.statSync(dir).isFile()) {
                         addWildcard = true;
                         wildcardName = node.specifiers[i].local.name;
                         node.specifiers.splice(i, 1);
@@ -73,12 +79,6 @@ export default function (babel) {
                         );
                         path.insertBefore(obj);
                     }
-                    
-                    // Get current filename so we can try to determine the folder
-                    var name = this.file.parserOpts.sourceFileName || this.file.parserOpts.filename;
-                    
-                    var files = [];
-                    var dir = _path.join(_path.dirname(name), src); // path of the target dir.
                     
                     // Will throw if the path does not point to a dir
                     try {

--- a/test/fixtures/fileWildcard/actual.js
+++ b/test/fixtures/fileWildcard/actual.js
@@ -1,0 +1,2 @@
+import * as all from './my-module.js';
+console.log(all.hello);

--- a/test/fixtures/fileWildcard/expected.js
+++ b/test/fixtures/fileWildcard/expected.js
@@ -1,0 +1,10 @@
+
+'use strict';
+
+var _myModule = require('./my-module.js');
+
+var all = _interopRequireWildcard(_myModule);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+console.log(all.hello);

--- a/test/fixtures/fileWildcard/my-module.js
+++ b/test/fixtures/fileWildcard/my-module.js
@@ -1,0 +1,1 @@
+export let hello = 'Hello World!';


### PR DESCRIPTION
Allow wildcard importing of files such as `import * as foo from './my-module.js'`.
