### PR TITLE
Added addtional check whether dir actually exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default function (babel) {
                 for (var i = node.specifiers.length - 1; i >= 0; i--) {
                     dec = node.specifiers[i];
                     
-                    if (t.isImportNamespaceSpecifier(dec) && !_fs.statSync(dir).isFile()) {
+                    if (t.isImportNamespaceSpecifier(dec) && _fs.existsSync(dir) && !_fs.statSync(dir).isFile()) {
                         addWildcard = true;
                         wildcardName = node.specifiers[i].local.name;
                         node.specifiers.splice(i, 1);


### PR DESCRIPTION
There might be the case when file actually exists and I want to import everything from it, but specify file without extension.

Example
```
-model
  |-people.js
  |-work.js
```
...with several exported classes each

I might want
```js
import * as model from './model'
import * as people from './model/people'
```
First case works as expected - it imports everything from folder
Second case throws an exception
```
Error: server/services/reports.js: ENOENT: no such file or directory, stat 'server/model/people'
```

So this PR fixes this behavior by checking if folder actually exists, and assumes this was file with missing extension otherwise.