### PR TITLE
Add support for path aliases and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,41 @@ this import:
 import * as tests from './dir/*.spec';
 ```
 
-will compile to:
+will (effectively) compile to:
 
 ```javascript
-import aSpec from './dir/a.spec';
-import bSpec from './dir/b.spec';
+const tests = {
+    aSpec: require('./dir/a.spec'),
+    bSpec: require('./dir/b.spec'),
+};
+```
+
+---
+
+Similarly, you can limit the files imported to a specific extension. With this directory structure:
+
+```
+|- index.js
+|- dir
+    |- a.js
+    |- b.jsx
+    |- c.jsx
+    |- d.js
+```
+
+and this import:
+
+```javascript
+import * as jsx from './dir/*.jsx';
+```
+
+will (effectively) compile to:
+
+```javascript
+const jsx = {
+    B: require('./dir/b.jsx'),
+    C: require('./dir/c.jsx'),
+};
 ```
 
 ---
@@ -186,3 +216,32 @@ you can disable this behavior using:
 ```
 
 Extensions are still removed (except dotfiles, see "Information").
+
+### `aliases` / `useWebpackAliases`
+By default, wildcards only work for paths that start with `.` or `/` (i.e. explicit relative/absolute paths). If your imports don't explicitly follow that pattern (i.e. you're using Webpack aliases) you can provide a list of aliases to help with path resolution like so:
+
+```javascript
+{
+    plugins: [
+        ['wildcard', {
+            'aliases' : {
+                'pathOne': '/some/path/to/alias',
+                'pathTwo': '/another/path/to/alias'
+            }
+        }]
+    ]
+}
+```
+
+If you've already defined a set of aliases in your Webpack config, just set the `useWebpackAliases` flag to `true`. By default, this will look for a `webpack.config.js` file in the CWD. You may specify a different path to your Webpack config file if necessary with the `webpackConfigFile` option.
+
+```javascript
+{
+    plugins: [
+        ['wildcard', {
+            'useWebpackAliases': true,
+            'webpackConfigFile' : '/path/to/webpack.config.js'
+        }]
+    ]
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -3,35 +3,76 @@ import _fs from 'fs';
 
 export default function (babel) {
     const { types: t } = babel;
-    
+
     return {
         visitor: {
             ImportDeclaration(path, state) {
-                let node = path.node, dec;
-                var src = path.node.source.value;
+                let node = path.node;
+                let dec;
 
-                // Don't do anything if not a relative path
-                // if if not a relative path then a module
-                if (src[0] !== "." && src[0] !== "/") return;
-                
-                let addWildcard = false, // True if should perform transform
-                wildcardName;        // Name of the variable the wilcard will go in
-                // not set if you have a filter { A, B, C }
-                
+                let pathAliases = {
+                    '.': _path.dirname(state.file.opts.filename), // get path of current file
+                };
+                Object.assign(pathAliases, state.opts.aliases || {});
+
+                // Support webpack aliases
+                if(state.opts.useWebpackAliases) {
+                    let webpackConfigFile = state.opts.webpackConfigFile || './webpack.config.js';
+                    if(webpackConfigFile[0] === '.' || webpackConfigFile[0] !== _path.sep) {
+                        webpackConfigFile = _path.join(process.cwd(), webpackConfigFile.substring(2));
+                    }
+                    let webpackConfig = require(webpackConfigFile);
+                    if(typeof webpackConfig === 'function') {
+                        webpackConfig = webpackConfig();
+                    }
+                    Object.assign(pathAliases, (webpackConfig.resolve && webpackConfig.resolve.alias) || {});
+                }
+
+                // add relative root alias to provided aliases
+                for(const alias in pathAliases) {
+                    const path = pathAliases[alias];
+                    if(path.length > 1 && path[0] === '.') {
+                        pathAliases[alias] = pathAliases['.'] + path.substring(1);
+                    }
+                }
+
+                // All the extensions that we should look at
+                let exts = state.opts.exts || ["js", "es6", "es", "jsx"];
+
+                let src = path.node.source.value.split(_path.sep);
+
+                // replace the alias with the actual path
+                const originalRoot = src[0];
+                const newRoot = pathAliases[src[0]] || src[0];
+                src[0] = newRoot;
+                src = src.join(_path.sep);
+
+                let wildcardName;           // Name of the variable the wilcard will go in
+                                            // not set if you have a filter { A, B, C }
+
                 let filterNames = []; // e.g. A, B, C
-                
+
                 // has a /* specifing explicitly to use wildcard
-                const wildcardRegex = /\/([^\/]*\*[^\/]*)$/;
+                const wildcardRegex = new RegExp(`\\${_path.sep}([^\\${_path.sep}]*\\*[^\\${_path.sep}]*)$`);
                 let isExplicitWildcard = wildcardRegex.test(src);
                 let filenameRegex = new RegExp('.+');
 
                 // in the above case we need to remove the trailing /*
                 if (isExplicitWildcard) {
-                    const lastSlash = path.node.source.value.lastIndexOf('/');
-                    src = path.node.source.value.substring(0, lastSlash);
-                    const filenameGlob = path.node.source.value.substring(lastSlash + 1);
-                    path.node.source.value = src;
-                    filenameRegex = filenameGlob.replace(/[*\.\(\[\)\]]/g, character => {
+                    const lastSlash = src.lastIndexOf(_path.sep);
+                    let filenameGlob = src.substring(lastSlash + 1).split('.');
+                    src = src.substring(0, lastSlash);
+
+                    const ext = filenameGlob[filenameGlob.length - 1];
+                    if(!!~exts.indexOf(ext)) {
+                        // filename ends in one of the extensions
+                        // so only look for those files
+                        exts = [ext];
+                        // and remove the extension from the glob
+                        filenameGlob.splice(-1, 1);
+                    }
+
+                    filenameRegex = filenameGlob.join('.').replace(/[*\.\(\[\)\]]/g, character => {
                         switch(character) {
                             case '*':
                                 return '.*';
@@ -46,159 +87,152 @@ export default function (babel) {
                     });
                     filenameRegex = new RegExp(filenameRegex);
                 }
-                
 
-                // Get current filename so we can try to determine the folder
-                var name = this.file.parserOpts.sourceFileName || this.file.parserOpts.filename;
+                if(!_fs.existsSync(src)) {
+                    // the path doesn't exist, so don't bother
+                    return;
+                }
+
+                if (!isExplicitWildcard) {
+                    // bypass resolution check if this is explicitly a wildcard path
+                    try {
+                        require.resolve(src);
+                        // the path resolves to a module normally so we shouldn't touch this
+                        return;
+                    } catch (err) {
+                        // if this errors it means the path doesn't automatically resolve to a module
+                        // in which case we need to see if we can apply the wildcard
+                        // as such, just swallow this error
+                    }
+                }
 
                 var files = [];
-                var dir = _path.join(_path.dirname(name), src); // path of the target dir.
 
                 for (var i = node.specifiers.length - 1; i >= 0; i--) {
                     dec = node.specifiers[i];
-                    
-                    if (t.isImportNamespaceSpecifier(dec) && _fs.existsSync(dir) && !_fs.statSync(dir).isFile()) {
-                        addWildcard = true;
-                        wildcardName = node.specifiers[i].local.name;
-                        node.specifiers.splice(i, 1);
+
+                    if (t.isImportNamespaceSpecifier(dec)) {
+                        wildcardName = dec.local.name;
                     }
-                    
-                    // This handles { A, B, C } from 'C/*'
-                    if (t.isImportSpecifier(dec) && isExplicitWildcard) {
+
+                    if(t.isImportSpecifier(dec)) {
+                        // This handles { A, B, C } from 'C/*'
                         // original: the actual name to lookup
                         // local: the name to import as, may be same as original
                         // We do this because of `import { A as B }`
-                        filterNames.push(
-                            {
-                                original: dec.imported.name,
-                                local: dec.local.name
-                            }
-                        );
-                        
-                        addWildcard = true;
-                        
-                        // Remove the specifier
-                        node.specifiers.splice(i, 1);
+                        filterNames.push({
+                            original: dec.imported.name,
+                            local: dec.local.name,
+                        });
                     }
-                    
+                    node.specifiers.splice(i, 1);
                 }
-                
-                // All the extensions that we should look at
-                var exts = state.opts.exts || ["js", "es6", "es", "jsx"];
-                
-                if (addWildcard) {
-                    // Add the original object. `import * as A from 'foo';`
-                    //  this creates `const A = {};`
-                    // For filters this will be empty anyway
-                    if (filterNames.length === 0) {
-                        var obj = t.variableDeclaration(
-                            "const", [
-                                t.variableDeclarator(t.identifier(wildcardName), t.objectExpression([]))
-                            ]
-                        );
-                        path.insertBefore(obj);
-                    }
-                    
-                    // Will throw if the path does not point to a dir
-                    try {
-                        let r = _fs.readdirSync(dir);
-                        for (var i = 0; i < r.length; i++) {
-                            // Check extension is of one of the aboves
-                            const {name, ext} = _path.parse(r[i]);
-                            if (exts.indexOf(ext.substring(1)) > -1 && filenameRegex.test(name)) {
-                                files.push(r[i]);
-                            }
+
+                // Add the original object. `import * as A from 'foo';`
+                //  this creates `const A = {};`
+                // For filters this will be empty anyway
+                if (!filterNames.length && wildcardName) {
+                    var obj = t.variableDeclaration(
+                        "const", [
+                            t.variableDeclarator(t.identifier(wildcardName), t.objectExpression([]))
+                        ]
+                    );
+                    path.insertBefore(obj);
+                }
+
+                // Will throw if the path does not point to a dir
+                try {
+                    let r = _fs.readdirSync(src);
+                    for (var i = 0; i < r.length; i++) {
+                        // Check extension is of one of the aboves
+                        const {name, ext} = _path.parse(r[i]);
+                        if (exts.indexOf(ext.substring(1)) > -1 && filenameRegex.test(name)) {
+                            files.push(r[i]);
                         }
-                    } catch(e) {
-                        console.warn(`Wildcard for ${name} points at ${src} which is not a directory.`);
-                        return;
+                    }
+                } catch(e) {
+                    console.warn(`${src} is not a directory.`);
+                    return;
+                }
+
+                // remove the absolute root
+                src = src.replace(newRoot, '').substring(1);
+
+                // This is quite a mess but it essentially formats the file
+                // extension, and adds it to the object
+                for (var i = 0; i < files.length; i++) {
+                    // name of temp. variable to store import before moved
+                    // to object
+                    let id = path.scope.generateUidIdentifier("wcImport");
+
+                    var file = files[i];
+
+                    // Strip extension
+                    var fancyName = file.replace(/(?!^)\.[^.\s]+$/, "");
+
+                    // Handle dotfiles, remove prefix `.` in that case
+                    if (fancyName[0] === ".") {
+                        fancyName = fancyName.substring(1);
                     }
 
-                    // This is quite a mess but it essentially formats the file
-                    // extension, and adds it to the object
-                    for (var i = 0; i < files.length; i++) {
-                        // name of temp. variable to store import before moved
-                        // to object
-                        let id = path.scope.generateUidIdentifier("wcImport");
-                        
-                        var file = files[i];
-                        
-                        // Strip extension
-                        var fancyName = file.replace(/(?!^)\.[^.\s]+$/, "");
-                        
-                        // Handle dotfiles, remove prefix `.` in that case
-                        if (fancyName[0] === ".") {
-                            fancyName = fancyName.substring(1);
-                        }
-                        
-                        // If we're allowed to camel case, which is default, we run it
-                        // through this regex which converts it to a PascalCase variable.
-                        if (state.opts.noCamelCase !== true) {
-                            fancyName = fancyName.match(/[A-Z][a-z]+(?![a-z])|[A-Z]+(?![a-z])|([a-zA-Z\d]+(?=-))|[a-zA-Z\d]+(?=_)|[a-z]+(?=[A-Z])|[A-Za-z0-9]+/g).map(s => s[0].toUpperCase() + s.substring(1)).join("");
-                        }
+                    // If we're allowed to camel case, which is default, we run it
+                    // through this regex which converts it to a PascalCase variable.
+                    if (state.opts.noCamelCase !== true) {
+                        fancyName = fancyName.match(/[A-Z][a-z]+(?![a-z])|[A-Z]+(?![a-z])|([a-zA-Z\d]+(?=-))|[a-zA-Z\d]+(?=_)|[a-z]+(?=[A-Z])|[A-Za-z0-9]+/g).map(s => s[0].toUpperCase() + s.substring(1)).join("");
+                    }
 
-                        // Now we're 100% settled on the fancyName, if the user
-                        // has provided a filer, we will check it:
-                        if (filterNames.length > 0) {
-                            // Find a filter name
-                            let res = null;
-                            for (let j = 0; j < filterNames.length; j++) {
-                                if (filterNames[j].original === fancyName) {
-                                    res = filterNames[j];
-                                    break;
-                                }
+                    // Now we're 100% settled on the fancyName, if the user
+                    // has provided a filer, we will check it:
+                    if (filterNames.length > 0) {
+                        // Find a filter name
+                        let res = null;
+                        for (let j = 0; j < filterNames.length; j++) {
+                            if (filterNames[j].original === fancyName) {
+                                res = filterNames[j];
+                                break;
                             }
-                            if (res === null) continue;
-                            fancyName = res.local;
                         }
-                        
-                        // This will remove file extensions from the generated `import`.
-                        // This is useful if your src/ files are for example .jsx or
-                        // .es6 but your generated files are of a different extension.
-                        // For situations like webpack you may want to disable this
-                        var name;
-                        if (state.opts.nostrip !== true) {
-                            name = "./" + _path.join(src, _path.basename(file));
-                        } else {
-                            name = "./" + _path.join(src, file);
-                        }
-                        
-                        // Special behavior if 'filterNames'
-                        if (filterNames.length > 0) {
-                            let importDeclaration = t.importDeclaration(
-                                [t.importDefaultSpecifier(
-                                    t.identifier(fancyName)
-                                )],
-                                t.stringLiteral(name)
-                            );
-                            path.insertAfter(importDeclaration);
-                            continue;
-                        }
-                        
-                        // Generate temp. import declaration
-                        let importDeclaration = t.importDeclaration(
-                            [t.importDefaultSpecifier(
-                                id
-                            )],
+                        if (res === null) continue;
+                        fancyName = res.local;
+                    }
+
+                    // This will remove file extensions from the generated `import`.
+                    // This is useful if your src/ files are for example .jsx or
+                    // .es6 but your generated files are of a different extension.
+                    // For situations like webpack you may want to disable this
+                    file = state.opts.nostrip !== true ? _path.basename(file) : file;
+                    const name = `${originalRoot}/${_path.join(src, file)}`;
+
+                    // Special behavior if 'filterNames'
+                    if (filterNames.length > 0) {
+                        path.insertAfter(t.importDeclaration(
+                            [t.importDefaultSpecifier(t.identifier(fancyName))],
                             t.stringLiteral(name)
-                        );
-                        
-                        // Assign it
-                        let thing = t.expressionStatement(
-                            t.assignmentExpression("=", t.memberExpression(
-                                t.identifier(wildcardName),
-                                t.stringLiteral(fancyName),
-                                true
-                            ), id
                         ));
-                        
-                        path.insertAfter(thing);
-                        path.insertAfter(importDeclaration);
+                        continue;
                     }
-                    
-                    if (path.node.specifiers.length === 0) {
-                        path.remove();
+
+                    if(wildcardName) {
+                        // Assign it
+                        path.insertAfter(t.expressionStatement(
+                            t.assignmentExpression(
+                                "=",
+                                t.memberExpression(t.identifier(wildcardName), t.stringLiteral(fancyName), true),
+                                id
+                            )
+                        ));
+                        // Generate temp. import declaration
+                        path.insertAfter(t.importDeclaration([t.importDefaultSpecifier(id)], t.stringLiteral(name)));
+                    } else {
+                        // if wildcardName is falsy it means the import doesn't get "captured"
+                        // e.g. import "./something/*"
+                        path.insertAfter(t.importDeclaration([], t.stringLiteral(name)));
                     }
+
+                }
+
+                if (path.node.specifiers.length === 0) {
+                    path.remove();
                 }
             }
         }

--- a/test/fixtures/alias/actual.js
+++ b/test/fixtures/alias/actual.js
@@ -1,0 +1,7 @@
+import * as manual from 'manualAlias/nested';
+import * as webpack from 'webpackAlias/nested';
+import * as unnested from 'manualAlias/unnested*';
+console.log(manual.Test());
+console.log(webpack.Test());
+console.log(unnested.Unnested());
+console.log(unnested.UnnestedAgain());

--- a/test/fixtures/alias/data/deep/structure/nested/test.js
+++ b/test/fixtures/alias/data/deep/structure/nested/test.js
@@ -1,0 +1,3 @@
+export default function () {
+    console.log('Nested!');
+}

--- a/test/fixtures/alias/data/deep/structure/unnested.js
+++ b/test/fixtures/alias/data/deep/structure/unnested.js
@@ -1,0 +1,3 @@
+export default function () {
+    console.log("This isn't quite as nested");
+}

--- a/test/fixtures/alias/data/deep/structure/unnested_again.js
+++ b/test/fixtures/alias/data/deep/structure/unnested_again.js
@@ -1,0 +1,3 @@
+export default function () {
+    console.log("Also un-nested and should be picked up by the glob");
+}

--- a/test/fixtures/alias/expected.js
+++ b/test/fixtures/alias/expected.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var _test = require('manualAlias/nested/test.js');
+
+var _test2 = _interopRequireDefault(_test);
+
+var _test3 = require('webpackAlias/nested/test.js');
+
+var _test4 = _interopRequireDefault(_test3);
+
+var _unnested_again = require('manualAlias/unnested_again.js');
+
+var _unnested_again2 = _interopRequireDefault(_unnested_again);
+
+var _unnested = require('manualAlias/unnested.js');
+
+var _unnested2 = _interopRequireDefault(_unnested);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var manual = {};
+manual['Test'] = _test2.default;
+var webpack = {};
+webpack['Test'] = _test4.default;
+var unnested = {};
+unnested['UnnestedAgain'] = _unnested_again2.default;
+unnested['Unnested'] = _unnested2.default;
+
+
+console.log(manual.Test());
+console.log(webpack.Test());
+console.log(unnested.Unnested());
+console.log(unnested.UnnestedAgain());

--- a/test/fixtures/alias/options.json
+++ b/test/fixtures/alias/options.json
@@ -1,0 +1,7 @@
+{
+    "aliases": {
+        "manualAlias": "./data/deep/structure"
+    },
+    "useWebpackAliases": true,
+    "webpackConfigFile": "./test/fixtures/alias/webpack.config.js"
+}

--- a/test/fixtures/alias/webpack.config.js
+++ b/test/fixtures/alias/webpack.config.js
@@ -1,0 +1,9 @@
+var path = require('path');
+
+module.exports = {
+    resolve: {
+        alias: {
+            webpackAlias: path.join(__dirname, 'data/deep/structure')
+        }
+    }
+};

--- a/test/fixtures/noCapture/actual.js
+++ b/test/fixtures/noCapture/actual.js
@@ -1,0 +1,1 @@
+import './data';

--- a/test/fixtures/noCapture/data/test.js
+++ b/test/fixtures/noCapture/data/test.js
@@ -1,0 +1,1 @@
+console.log('No Export!');

--- a/test/fixtures/noCapture/expected.js
+++ b/test/fixtures/noCapture/expected.js
@@ -1,0 +1,3 @@
+'use strict';
+
+require('./data/test.js');

--- a/test/fixtures/null/actual.js
+++ b/test/fixtures/null/actual.js
@@ -1,0 +1,2 @@
+import File from './data/file';
+console.log(File());

--- a/test/fixtures/null/data/file.js
+++ b/test/fixtures/null/data/file.js
@@ -1,0 +1,3 @@
+export default function () {
+    console.log('actual file');
+}

--- a/test/fixtures/null/expected.js
+++ b/test/fixtures/null/expected.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var _file = require('./data/file');
+
+var _file2 = _interopRequireDefault(_file);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log((0, _file2.default)());

--- a/test/fixtures/specificExtension/actual.js
+++ b/test/fixtures/specificExtension/actual.js
@@ -1,0 +1,4 @@
+import * as js from './data/*.js';
+import * as es6 from './data/*.es6';
+console.log(js.Test());
+console.log(es6.Test());

--- a/test/fixtures/specificExtension/data/test.es6
+++ b/test/fixtures/specificExtension/data/test.es6
@@ -1,0 +1,3 @@
+export default function () {
+    console.log('ES6 file');
+}

--- a/test/fixtures/specificExtension/data/test.js
+++ b/test/fixtures/specificExtension/data/test.js
@@ -1,0 +1,3 @@
+export default function () {
+    console.log('Normal Javascript file');
+}

--- a/test/fixtures/specificExtension/expected.js
+++ b/test/fixtures/specificExtension/expected.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var _test = require('./data/test.js');
+
+var _test2 = _interopRequireDefault(_test);
+
+var _test3 = require('./data/test.es6');
+
+var _test4 = _interopRequireDefault(_test3);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var js = {};
+js['Test'] = _test2.default;
+var es6 = {};
+es6['Test'] = _test4.default;
+
+console.log(js.Test());
+console.log(es6.Test());

--- a/test/index.js
+++ b/test/index.js
@@ -24,8 +24,12 @@ function runTests() {
 }
 
 function runTest(dir) {
+	var opts = {};
+	try {
+		opts = JSON.parse(fs.readFileSync(dir.path + '/options.json', 'utf-8'));
+    } catch(err) {}
 	var output = babel.transformFileSync(dir.path + '/actual.js', {
-		plugins: [pluginPath],
+		plugins: [[pluginPath, opts]],
         presets: []
 	});
 


### PR DESCRIPTION
This is a lot bigger than I had intended, I just kept finding little things to add. Anyway, here's what's changed:
- Add aliases config option to specify aliases for path resolution
- Support path aliases from webpack config
- Better wildcard detection using `require.resolve`
- Support "uncaptured" imports (e.g. `import 'some/path';`)
- Support specifying explicit extensions per wildcard import
- Use `path.sep` rather than hardcoded `/` for better cross-platform support