### PR TITLE
exclude node_modules to prevent issues in dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ export default function (babel) {
     return {
         visitor: {
             ImportDeclaration(path, state) {
+                //Don't do anything inside node_modules
+                if (_path.relative(state.file.opts.root, state.file.opts.filename).match(/^node_modules/)) return;
+
                 let node = path.node, dec;
                 var src = path.node.source.value;
 


### PR DESCRIPTION
I was having some issues using `react-native-modal`, due to their dependency `react-native-animatable` doing this:
```
import * as ANIMATION_DEFINITIONS from './definitions';
```
I don't see any reason why wildcard should affect dependencies in `node_modules`, so I think it's best we exclude it.
Making this change seemed to fix my issue.


Relatedly, another thing to do on top of this would be to not modify the import if there already exists an `index.js` file in the directory being referenced. If the file does exist, the intention is probably to reference it directly, rather than to use wildcard to grab all files.
Also, if this is implemented, it would allow for imports without the explicit wildcard in more cases (ie: `import {A, B} from './dir` could work if `./dir` doesn't contain an index file), which could be useful to some people.