### PR TITLE
Adds support for empty exts array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ export default function (babel) {
                         for (var i = 0; i < r.length; i++) {
                             // Check extension is of one of the aboves
                             const {name, ext} = _path.parse(r[i]);
-                            if (exts.indexOf(ext.substring(1)) > -1 && filenameRegex.test(name)) {
+                            if ((exts.length === 0 || exts.indexOf(ext.substring(1))) > -1 && filenameRegex.test(name)) {
                                 files.push(r[i]);
                                 isDirs.push(!ext);
                             }


### PR DESCRIPTION
Currently it is not possible to not do any extension filtering at all. This PR checks for an empty array.