### PR TITLE
fix: Ignore directories with an index.js file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,8 @@ export default function (babel) {
                     if (
                         t.isImportNamespaceSpecifier(dec) &&
                         _fs.existsSync(dir) &&
-                        !_fs.statSync(dir).isFile()
+                        !_fs.statSync(dir).isFile() &&
+                        !_fs.existsSync(_path.join(dir, 'index.js'))
                     ) {
                         addWildcard = true;
                         wildcardName = node.specifiers[i].local.name;

--- a/test/fixtures/index/actual.js
+++ b/test/fixtures/index/actual.js
@@ -1,0 +1,2 @@
+import * as files from './data/';
+console.log(files);

--- a/test/fixtures/index/data/foo.js
+++ b/test/fixtures/index/data/foo.js
@@ -1,0 +1,1 @@
+module.exports = 2

--- a/test/fixtures/index/data/index.js
+++ b/test/fixtures/index/data/index.js
@@ -1,0 +1,1 @@
+module.exports = 1

--- a/test/fixtures/index/expected.js
+++ b/test/fixtures/index/expected.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var _data = require('./data/');
+
+var files = _interopRequireWildcard(_data);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+console.log(files);


### PR DESCRIPTION
The plugin should only handle imports that do not actually import a file but only a directory. This PR ignores directories with an index.js (which in turn can define the exports).